### PR TITLE
User verification fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,4 +90,5 @@ Do this as follows:
     - Ensure that the following permissions are enabled
         - `Microsoft Graph` > `User.Read.All` (application)
         - `Microsoft Graph` > `GroupMember.Read.All` (application)
+        - `Microsoft Graph` > `User.Read.All` (delegated)
     - Select this and click the `Grant admin consent` button (otherwise manual consent is needed from each user)

--- a/apricot/ldap/oauth_ldap_entry.py
+++ b/apricot/ldap/oauth_ldap_entry.py
@@ -75,10 +75,11 @@ class OAuthLDAPEntry(ReadOnlyInMemoryLDAPEntry):
 
     def bind(self, password: bytes) -> defer.Deferred["OAuthLDAPEntry"]:
         def _bind(password: bytes) -> "OAuthLDAPEntry":
+            oauth_username = next(iter(self.get("oauth_username", "unknown")))
             s_password = password.decode("utf-8")
-            if self.oauth_client.verify(username=self.username, password=s_password):
+            if self.oauth_client.verify(username=oauth_username, password=s_password):
                 return self
-            msg = f"Invalid password for user '{self.username}'."
+            msg = f"Invalid password for user '{oauth_username}'."
             raise LDAPInvalidCredentials(msg)
 
         return defer.maybeDeferred(_bind, password)

--- a/apricot/ldap/oauth_ldap_tree.py
+++ b/apricot/ldap/oauth_ldap_tree.py
@@ -3,6 +3,7 @@ import time
 from ldaptor.interfaces import IConnectedLDAPEntry, ILDAPEntry
 from ldaptor.protocols.ldap.distinguishedname import DistinguishedName
 from twisted.internet import defer
+from twisted.python import log
 from zope.interface import implementer
 
 from apricot.ldap.oauth_ldap_entry import OAuthLDAPEntry
@@ -36,6 +37,7 @@ class OAuthLDAPTree:
             not self.root_
             or (time.monotonic() - self.last_update) > self.refresh_interval
         ):
+            log.msg("Rebuilding LDAP tree from OAuth data.")
             # Create a root node for the tree
             self.root_ = OAuthLDAPEntry(
                 dn=self.oauth_client.root_dn,
@@ -55,6 +57,9 @@ class OAuthLDAPTree:
             # Add users to the users OU
             for user_attrs in self.oauth_client.validated_users():
                 users_ou.add_child(f"CN={user_attrs['cn'][0]}", user_attrs)
+            # Set last updated time
+            log.msg("Finished building LDAP tree.")
+            self.last_update = time.monotonic()
         return self.root_
 
     def __repr__(self) -> str:

--- a/apricot/ldap/read_only_ldap_server.py
+++ b/apricot/ldap/read_only_ldap_server.py
@@ -15,6 +15,10 @@ from apricot.oauth import LDAPControlTuple
 
 
 class ReadOnlyLDAPServer(LDAPServer):
+    def __init__(self) -> None:
+        super().__init__()
+        self.debug = True
+
     def getRootDSE(  # noqa: N802
         self,
         request: LDAPBindRequest,

--- a/apricot/ldap/read_only_ldap_server.py
+++ b/apricot/ldap/read_only_ldap_server.py
@@ -11,6 +11,8 @@ from ldaptor.protocols.pureldap import (
 )
 from twisted.internet import defer
 
+from apricot.oauth import LDAPControlTuple
+
 
 class ReadOnlyLDAPServer(LDAPServer):
     def getRootDSE(  # noqa: N802
@@ -26,7 +28,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPAddRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -39,7 +41,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPBindRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -50,7 +52,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPCompareRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -61,7 +63,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPDelRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -74,7 +76,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPExtendedRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -85,7 +87,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPModifyDNRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -98,7 +100,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPModifyRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """
@@ -111,7 +113,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPUnbindRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[..., None] | None,
     ) -> None:
         """
@@ -122,7 +124,7 @@ class ReadOnlyLDAPServer(LDAPServer):
     def handle_LDAPSearchRequest(  # noqa: N802
         self,
         request: LDAPBindRequest,
-        controls: LDAPControl | None,
+        controls: list[LDAPControlTuple] | None,
         reply: Callable[[LDAPSearchResultEntry], None] | None,
     ) -> defer.Deferred[ILDAPEntry]:
         """

--- a/apricot/models/__init__.py
+++ b/apricot/models/__init__.py
@@ -1,6 +1,7 @@
 from .ldap_group_of_names import LdapGroupOfNames
 from .ldap_inetorgperson import LdapInetOrgPerson
 from .ldap_inetuser import LdapInetUser
+from .ldap_oauthuser import LdapOAuthUser
 from .ldap_person import LdapPerson
 from .ldap_posix_account import LdapPosixAccount
 from .ldap_posix_group import LdapPosixGroup
@@ -9,6 +10,7 @@ __all__ = [
     "LdapGroupOfNames",
     "LdapInetOrgPerson",
     "LdapInetUser",
+    "LdapOAuthUser",
     "LdapPerson",
     "LdapPosixAccount",
     "LdapPosixGroup",

--- a/apricot/models/ldap_oauthuser.py
+++ b/apricot/models/ldap_oauthuser.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+
+class LdapOAuthUser(BaseModel):
+    oauth_username: str

--- a/apricot/oauth/__init__.py
+++ b/apricot/oauth/__init__.py
@@ -1,12 +1,13 @@
 from .enums import OAuthBackend
 from .microsoft_entra_client import MicrosoftEntraClient
 from .oauth_client import OAuthClient
-from .types import LDAPAttributeDict
+from .types import LDAPAttributeDict, LDAPControlTuple
 
 OAuthClientMap = {OAuthBackend.MICROSOFT_ENTRA: MicrosoftEntraClient}
 
 __all__ = [
     "LDAPAttributeDict",
+    "LDAPControlTuple",
     "OAuthBackend",
     "OAuthClient",
     "OAuthClientMap",

--- a/apricot/oauth/microsoft_entra_client.py
+++ b/apricot/oauth/microsoft_entra_client.py
@@ -82,6 +82,8 @@ class MicrosoftEntraClient(OAuthClient):
                 sorted(user_data["value"], key=lambda user: user["createdDateTime"]),
             ):
                 # Get user attributes
+                given_name = user_dict.get("givenName", None)
+                surname = user_dict.get("surname", None)
                 uid, domain = str(user_dict.get("userPrincipalName", "@")).split("@")
                 user_uid = self.uid_cache.get_user_uid(user_dict["id"])
                 attributes = {}
@@ -90,10 +92,10 @@ class MicrosoftEntraClient(OAuthClient):
                 attributes["displayName"] = user_dict.get("displayName", None)
                 attributes["domain"] = domain
                 attributes["gidNumber"] = user_uid
-                attributes["givenName"] = user_dict.get("givenName", "")
+                attributes["givenName"] = given_name if given_name else ""
                 attributes["homeDirectory"] = f"/home/{uid}" if uid else None
                 attributes["oauth_username"] = user_dict.get("userPrincipalName", None)
-                attributes["sn"] = user_dict.get("surname", "")
+                attributes["sn"] = surname if surname else ""
                 attributes["uid"] = uid if uid else None
                 attributes["uidNumber"] = user_uid
                 # Add group attributes

--- a/apricot/oauth/microsoft_entra_client.py
+++ b/apricot/oauth/microsoft_entra_client.py
@@ -87,11 +87,12 @@ class MicrosoftEntraClient(OAuthClient):
                 attributes = {}
                 attributes["cn"] = user_dict.get("displayName", None)
                 attributes["description"] = user_dict.get("id", None)
-                attributes["displayName"] = attributes.get("cn", None)
+                attributes["displayName"] = user_dict.get("displayName", None)
                 attributes["domain"] = domain
                 attributes["gidNumber"] = user_uid
                 attributes["givenName"] = user_dict.get("givenName", "")
                 attributes["homeDirectory"] = f"/home/{uid}" if uid else None
+                attributes["oauth_username"] = user_dict.get("userPrincipalName", None)
                 attributes["sn"] = user_dict.get("surname", "")
                 attributes["uid"] = uid if uid else None
                 attributes["uidNumber"] = user_uid

--- a/apricot/oauth/oauth_client.py
+++ b/apricot/oauth/oauth_client.py
@@ -18,6 +18,7 @@ from apricot.models import (
     LdapGroupOfNames,
     LdapInetOrgPerson,
     LdapInetUser,
+    LdapOAuthUser,
     LdapPerson,
     LdapPosixAccount,
     LdapPosixGroup,
@@ -207,6 +208,10 @@ class OAuthClient(ABC):
                 posix_account = LdapPosixAccount(**user_dict)
                 attributes.update(posix_account.model_dump())
                 attributes["objectclass"].append("posixAccount")
+                # Add 'OAuthUser' attributes
+                oauth_user = LdapOAuthUser(**user_dict)
+                attributes.update(oauth_user.model_dump())
+                attributes["objectclass"].append("oauthUser")
                 # Ensure that all values are lists as required for LDAPAttributeDict
                 output.append(
                     {

--- a/apricot/oauth/types.py
+++ b/apricot/oauth/types.py
@@ -2,3 +2,4 @@ from typing import Any
 
 JSONDict = dict[str, str | list[str]]
 LDAPAttributeDict = dict[str, list[Any]]
+LDAPControlTuple = tuple[str, bool, Any]


### PR DESCRIPTION
- Fix some incorrect type hints
- Fix LDAP tree building
- Fix a missing `username` attribute when connecting to an OAuth backend
- Improve logging
- Entra: require that delegated `User.Read.All` permission in addition to previous permissions.

Closes #24