### PR TITLE
Fix user group names

### DIFF
--- a/apricot/oauth/oauth_client.py
+++ b/apricot/oauth/oauth_client.py
@@ -151,6 +151,8 @@ class OAuthClient(ABC):
         for user_dict in self.users():
             user_dict["memberUid"] = [user_dict["uid"]]
             user_dict["member"] = [f"CN={user_dict['uid']},OU=users,{self.root_dn}"]
+            # Group name is taken from 'cn' which should match the username
+            user_dict["cn"] = user_dict["uid"]
             user_group_dicts.append(user_dict)
         # Iterate over groups and validate them
         for group_dict in self.groups() + user_group_dicts:

--- a/apricot/oauth/oauth_client.py
+++ b/apricot/oauth/oauth_client.py
@@ -150,7 +150,7 @@ class OAuthClient(ABC):
         user_group_dicts = []
         for user_dict in self.users():
             user_dict["memberUid"] = [user_dict["uid"]]
-            user_dict["member"] = [f"CN={user_dict['uid']},OU=users,{self.root_dn}"]
+            user_dict["member"] = [f"CN={user_dict['cn']},OU=users,{self.root_dn}"]
             # Group name is taken from 'cn' which should match the username
             user_dict["cn"] = user_dict["uid"]
             user_group_dicts.append(user_dict)


### PR DESCRIPTION
- Ensure that the `member` attribute of the group uses the correct `dn` for the associated user
- Use user `uid` as the `cn` of the associated group since this will be used as the group name