### PR TITLE
Fix Microsoft Entra group processing

### DIFF
--- a/apricot/oauth/microsoft_entra_client.py
+++ b/apricot/oauth/microsoft_entra_client.py
@@ -56,7 +56,7 @@ class MicrosoftEntraClient(OAuthClient):
                 attributes["memberUid"] = [
                     str(user["userPrincipalName"]).split("@")[0]
                     for user in members["value"]
-                    if user["userPrincipalName"]
+                    if user.get("userPrincipalName")
                 ]
                 output.append(attributes)
             except KeyError as exc:


### PR DESCRIPTION
Fix issue where a Microsoft Entra group containing a user without a `userPrincipalName` would cause group processing to silently end.

Closes #39 