### PR TITLE
Allow specification of attribute for domain in KeycloakClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Instructions for specific OpenID Connect backends below.
 You will need to use the following command line arguments:
 
 ```bash
---backend MicrosoftEntra --entra-tenant-id "<your tenant ID>"
+--backend MicrosoftEntra \
+--entra-tenant-id "<your tenant ID>"
 ```
 
 You will need to register an application to interact with `Microsoft Entra`.
@@ -200,7 +201,10 @@ Do this as follows:
 You will need to use the following command line arguments:
 
 ```bash
---backend Keycloak --keycloak-base-url "<your hostname>/<path to keycloak>" --keycloak-realm "<your realm>" --keycloak-domain-attribute "<your domain attribute>"
+--backend Keycloak \
+--keycloak-base-url "<your hostname>/<path to keycloak>" \
+--keycloak-domain-attribute "<the attribute used as your domain>" \
+--keycloak-realm "<your realm>"
 ```
 
 You will need to register an application to interact with `Keycloak`.
@@ -219,7 +223,7 @@ Do this as follows:
     - `User attribute`
         - => Every user has an attribute for the domain
         - name: `domain`
-        - user attribute: `<the attribute to use as domain>`
+        - user attribute: `<the attribute used as your domain>`
         - token claim name: `domain`
 - Create a new `Client` in your `Keycloak` instance.
     - Set the name to whatever you choose (e.g. `apricot`)
@@ -236,4 +240,3 @@ Do this as follows:
         - `realm-management` > `query-groups`
         - `realm-management` > `query-users`
 - Under `Client scopes` click `Add client scope` > `domainScope`. Make sure to select type `Default`
-

--- a/README.md
+++ b/README.md
@@ -200,12 +200,27 @@ Do this as follows:
 You will need to use the following command line arguments:
 
 ```bash
---backend Keycloak --keycloak-base-url "<your hostname>/<path to keycloak>" --keycloak-realm "<your realm>"
+--backend Keycloak --keycloak-base-url "<your hostname>/<path to keycloak>" --keycloak-realm "<your realm>" --keycloak-domain-attribute "<your domain attribute>"
 ```
 
 You will need to register an application to interact with `Keycloak`.
 Do this as follows:
 
+- Under the realm option `Client scopes` create a new scope, e.g. `domainScope` with:
+    - Type: `Default`
+    - Include in token scope: `true`
+    - Save
+- In the created scope click `Mappers` > `Configure new mapper` and now create either
+    - `Hardcoded claim`
+        - => Every user gets the same domain
+        - name: `domain`
+        - token claim name: `domain`
+        - claim value: `<your domain>`
+    - `User attribute`
+        - => Every user has an attribute for the domain
+        - name: `domain`
+        - user attribute: `<the attribute to use as domain>`
+        - token claim name: `domain`
 - Create a new `Client` in your `Keycloak` instance.
     - Set the name to whatever you choose (e.g. `apricot`)
     - Enable `Client authentication`
@@ -220,3 +235,5 @@ Do this as follows:
         - `realm-management` > `manage-users`
         - `realm-management` > `query-groups`
         - `realm-management` > `query-users`
+- Under `Client scopes` click `Add client scope` > `domainScope`. Make sure to select type `Default`
+

--- a/apricot/oauth/keycloak_client.py
+++ b/apricot/oauth/keycloak_client.py
@@ -17,6 +17,7 @@ class KeycloakClient(OAuthClient):
         self: Self,
         keycloak_base_url: str,
         keycloak_realm: str,
+        keycloak_domain_attribute: str,
         **kwargs: Any,
     ) -> None:
         """Initialise a KeycloakClient.
@@ -26,6 +27,7 @@ class KeycloakClient(OAuthClient):
         """
         self.base_url = keycloak_base_url
         self.realm = keycloak_realm
+        self.domain_attribute = keycloak_domain_attribute
 
         redirect_uri = "urn:ietf:wg:oauth:2.0:oob"  # this is the "no redirect" URL
         scopes: list[str] = []  # this is the default scope
@@ -162,6 +164,7 @@ class KeycloakClient(OAuthClient):
                 attributes["oauth_id"] = user_dict.get("id", None)
                 attributes["sn"] = last_name or ""
                 attributes["uidNumber"] = user_dict["attributes"]["uid"][0]
+                attributes["domain"] = user_dict["attributes"].get(self.domain_attribute, [None])[0]
                 output.append(attributes)
         except KeyError:
             pass

--- a/apricot/oauth/keycloak_client.py
+++ b/apricot/oauth/keycloak_client.py
@@ -156,7 +156,10 @@ class KeycloakClient(OAuthClient):
                 attributes["cn"] = username
                 attributes["description"] = ""
                 attributes["displayName"] = full_name
-                attributes["domain"] = user_dict["attributes"].get(self.domain_attribute, [None])[0]
+                attributes["domain"] = user_dict["attributes"].get(
+                    self.domain_attribute,
+                    [None],
+                )[0]
                 attributes["gidNumber"] = user_dict["attributes"]["uid"][0]
                 attributes["givenName"] = first_name or ""
                 attributes["homeDirectory"] = f"/home/{username}" if username else None

--- a/apricot/oauth/keycloak_client.py
+++ b/apricot/oauth/keycloak_client.py
@@ -16,18 +16,19 @@ class KeycloakClient(OAuthClient):
     def __init__(
         self: Self,
         keycloak_base_url: str,
-        keycloak_realm: str,
         keycloak_domain_attribute: str,
+        keycloak_realm: str,
         **kwargs: Any,
     ) -> None:
         """Initialise a KeycloakClient.
 
         @param keycloak_base_url: Base URL for Keycloak server
+        @param keycloak_domain_attribute: Keycloak attribute used to define your domain
         @param keycloak_realm: Realm for Keycloak server
         """
         self.base_url = keycloak_base_url
-        self.realm = keycloak_realm
         self.domain_attribute = keycloak_domain_attribute
+        self.realm = keycloak_realm
 
         redirect_uri = "urn:ietf:wg:oauth:2.0:oob"  # this is the "no redirect" URL
         scopes: list[str] = []  # this is the default scope
@@ -153,18 +154,18 @@ class KeycloakClient(OAuthClient):
                 username = user_dict.get("username")
                 attributes: JSONDict = {}
                 attributes["cn"] = username
-                attributes["uid"] = username
-                attributes["oauth_username"] = username
-                attributes["displayName"] = full_name
-                attributes["mail"] = user_dict.get("email")
                 attributes["description"] = ""
+                attributes["displayName"] = full_name
+                attributes["domain"] = user_dict["attributes"].get(self.domain_attribute, [None])[0]
                 attributes["gidNumber"] = user_dict["attributes"]["uid"][0]
                 attributes["givenName"] = first_name or ""
                 attributes["homeDirectory"] = f"/home/{username}" if username else None
+                attributes["mail"] = user_dict.get("email")
                 attributes["oauth_id"] = user_dict.get("id", None)
+                attributes["oauth_username"] = username
                 attributes["sn"] = last_name or ""
+                attributes["uid"] = username
                 attributes["uidNumber"] = user_dict["attributes"]["uid"][0]
-                attributes["domain"] = user_dict["attributes"].get(self.domain_attribute, [None])[0]
                 output.append(attributes)
         except KeyError:
             pass

--- a/run.py
+++ b/run.py
@@ -82,6 +82,12 @@ if __name__ == "__main__":
             type=str,
             help="Keycloak Realm.",
         )
+        keycloak_group.add_argument(
+            "--keycloak-domain-attribute",
+            type=str,
+            default="domain",
+            help="The attribute in Keycloak that contains the users' domain.",
+        )
         # Options for Redis cache
         redis_group = parser.add_argument_group("Redis")
         redis_group.add_argument(


### PR DESCRIPTION
In the current state it was not possible to use the Keycloak-Backend as there was no definition how to parse the domain from a user.

I've added a CLI-flag to specify which OIDC-attribute should be mapped to the domain in the user_dict.