### PR TITLE
Update Keycloak backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,8 +151,8 @@ Do this as follows:
 
 - Create a new `Client` in your `Keycloak` instance.
     - Under `General Settings`:
-        -  Client type: `OpenID Connect`
-        -  Client name: `apricot`
+        - Client type: `OpenID Connect`
+        - Client name: `apricot`
     - Under `Capability config`
         - Enable `Client authentication`
         - Enable the following authentication flows and disable the rest:
@@ -160,14 +160,14 @@ Do this as follows:
             - `Service accounts roles`
     - Save the client
 - For the client you have just created
-  - Under `Credentials` copy `client secret`
-  - Under `Service accounts roles`:
-      - Click on `Assign role` then `Filter by clients`
-      - Assign the following roles:
-          - `realm-management` > `view-users`
-          - `realm-management` > `manage-users`
-          - `realm-management` > `query-groups`
-          - `realm-management` > `query-users`
+    - Under `Credentials` copy `client secret`
+    - Under `Service accounts roles`:
+        - Click on `Assign role` then `Filter by clients`
+        - Assign the following roles:
+            - `realm-management` > `view-users`
+            - `realm-management` > `manage-users`
+            - `realm-management` > `query-groups`
+            - `realm-management` > `query-users`
 
 ## Disabling Apricot groups
 
@@ -202,7 +202,6 @@ member: CN=sherlock.holmes,OU=users,DC=example,DC=com
 ```
 
 :exclamation: You can disable the creation of these groups with the `--disable-primary-groups` command line option :exclamation:
-
 
 ## Mirrored groups
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ The value of this attribute should be the same as the `--domain` argument to Apr
 Any users with this attribute missing or set to something else will be ignored by Apricot.
 This allows you to attach multiple Apricot servers to the same Keycloak instance, each with their own set of users.
 
+:exclamation: You can disable user domain verification with the `--disable-user-domain-verification` command line option :exclamation:
+
 #### Client application
 
 You will need to register an application to interact with `Keycloak`.

--- a/README.md
+++ b/README.md
@@ -207,36 +207,36 @@ You will need to use the following command line arguments:
 --keycloak-realm "<your realm>"
 ```
 
+#### User attribute
+
+You will need to add a custom attribute to each user you want Apricot to use.
+The name of this attribute should be used as the value of the `--keycloak-domain-attribute` argument above.
+The value of this attribute should be the same as the `--domain` argument to Apricot.
+
+Any users with this attribute missing or set to something else will be ignored by Apricot.
+This allows you to attach multiple Apricot servers to the same Keycloak instance, each with their own set of users.
+
+#### Client application
+
 You will need to register an application to interact with `Keycloak`.
 Do this as follows:
 
-- Under the realm option `Client scopes` create a new scope, e.g. `domainScope` with:
-    - Type: `Default`
-    - Include in token scope: `true`
-    - Save
-- In the created scope click `Mappers` > `Configure new mapper` and now create either
-    - `Hardcoded claim`
-        - => Every user gets the same domain
-        - name: `domain`
-        - token claim name: `domain`
-        - claim value: `<your domain>`
-    - `User attribute`
-        - => Every user has an attribute for the domain
-        - name: `domain`
-        - user attribute: `<the attribute used as your domain>`
-        - token claim name: `domain`
 - Create a new `Client` in your `Keycloak` instance.
-    - Set the name to whatever you choose (e.g. `apricot`)
-    - Enable `Client authentication`
-    - Enable the following authentication flows and disable the rest:
-        - Direct access grants
-        - Service account roles
-- Under `Credentials` copy `client secret`
-- Under `Service account roles`:
-    - Click on `Assign role` then `Filter by clients`
-    - Assign the following roles:
-        - `realm-management` > `view-users`
-        - `realm-management` > `manage-users`
-        - `realm-management` > `query-groups`
-        - `realm-management` > `query-users`
-- Under `Client scopes` click `Add client scope` > `domainScope`. Make sure to select type `Default`
+    - Under `General Settings`:
+        -  Client type: `OpenID Connect`
+        -  Client name: `apricot`
+    - Under `Capability config`
+        - Enable `Client authentication`
+        - Enable the following authentication flows and disable the rest:
+            - `Direct access grants`
+            - `Service accounts roles`
+    - Save the client
+- For the client you have just created
+  - Under `Credentials` copy `client secret`
+  - Under `Service accounts roles`:
+      - Click on `Assign role` then `Filter by clients`
+      - Assign the following roles:
+          - `realm-management` > `view-users`
+          - `realm-management` > `manage-users`
+          - `realm-management` > `query-groups`
+          - `realm-management` > `query-users`

--- a/apricot/apricot_server.py
+++ b/apricot/apricot_server.py
@@ -28,6 +28,7 @@ class ApricotServer:
         background_refresh: bool = False,
         debug: bool = False,
         enable_mirrored_groups: bool = True,
+        enable_user_domain_verification: bool = True,
         redis_host: str | None = None,
         redis_port: int | None = None,
         refresh_interval: int = 60,
@@ -45,7 +46,8 @@ class ApricotServer:
         @param port: Port to expose LDAP on
         @param background_refresh: Whether to refresh the LDAP tree in the background
         @param debug: Enable debug output
-        @param enable_mirrored_groups: Create a mirrored LDAP group-of-groups for each group-of-users
+        @param enable_mirrored_groups: Whether to create a mirrored LDAP group-of-groups for each group-of-users
+        @param enable_user_domain_verification: Whether to verify users belong to the correct domain
         @param redis_host: Host for a Redis cache (if used)
         @param redis_port: Port for a Redis cache (if used)
         @param refresh_interval: Interval after which the LDAP information is stale
@@ -93,6 +95,7 @@ class ApricotServer:
             domain,
             oauth_client,
             enable_mirrored_groups=enable_mirrored_groups,
+            enable_user_domain_verification=enable_user_domain_verification,
         )
 
         # Create an LDAPServerFactory

--- a/apricot/apricot_server.py
+++ b/apricot/apricot_server.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 import inspect
 import sys
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from twisted.internet import reactor, task
 from twisted.internet.endpoints import quoteStringArgument, serverFromString
-from twisted.internet.interfaces import IReactorCore, IStreamServerEndpoint
 from twisted.python import log
 
 from apricot.cache import LocalCache, RedisCache, UidCache
 from apricot.ldap import OAuthLDAPServerFactory
 from apricot.oauth import OAuthBackend, OAuthClientMap, OAuthDataAdaptor
+
+if TYPE_CHECKING:
+    from twisted.internet.interfaces import IReactorCore, IStreamServerEndpoint
 
 
 class ApricotServer:
@@ -139,7 +141,7 @@ class ApricotServer:
             ssl_endpoint.listen(factory)
 
         # Load the Twisted reactor
-        self.reactor = cast(IReactorCore, reactor)
+        self.reactor = cast("IReactorCore", reactor)
 
     def run(self: Self) -> None:
         """Start the Twisted reactor."""

--- a/apricot/cache/redis_cache.py
+++ b/apricot/cache/redis_cache.py
@@ -42,4 +42,4 @@ class RedisCache(UidCache):
         self.cache.set(identifier, uid_value)
 
     def values(self: Self, keys: list[str]) -> list[int]:
-        return [int(cast(str, v)) for v in self.cache.mget(keys)]
+        return [int(cast("str", v)) for v in self.cache.mget(keys)]

--- a/apricot/cache/uid_cache.py
+++ b/apricot/cache/uid_cache.py
@@ -55,7 +55,7 @@ class UidCache(ABC):
             min_value = min_value or 0
             next_uid = max(self._get_max_uid(category) + 1, min_value)
             self.set(identifier_, next_uid)
-        return cast(int, self.get(identifier_))
+        return cast("int", self.get(identifier_))
 
     def _get_max_uid(self: Self, category: str | None) -> int:
         """Get maximum UID for a given category.

--- a/apricot/ldap/oauth_ldap_entry.py
+++ b/apricot/ldap/oauth_ldap_entry.py
@@ -75,7 +75,7 @@ class OAuthLDAPEntry(ReadOnlyInMemoryLDAPEntry):
         except LDAPEntryAlreadyExists:
             log.msg(f"Refusing to add child '{rdn.getText()}' as it already exists.")
             output = self._children[rdn.getText()]
-        return cast(OAuthLDAPEntry, output)
+        return cast("OAuthLDAPEntry", output)
 
     def bind(self: Self, password: bytes) -> defer.Deferred[OAuthLDAPEntry]:
         def _bind(password: bytes) -> OAuthLDAPEntry:
@@ -89,4 +89,4 @@ class OAuthLDAPEntry(ReadOnlyInMemoryLDAPEntry):
         return defer.maybeDeferred(_bind, password)
 
     def list_children(self: Self) -> list[OAuthLDAPEntry]:
-        return [cast(OAuthLDAPEntry, entry) for entry in self._children.values()]
+        return [cast("OAuthLDAPEntry", entry) for entry in self._children.values()]

--- a/apricot/ldap/oauth_ldap_server_factory.py
+++ b/apricot/ldap/oauth_ldap_server_factory.py
@@ -3,7 +3,7 @@ from typing import Self
 from twisted.internet.interfaces import IAddress
 from twisted.internet.protocol import Protocol, ServerFactory
 
-from apricot.oauth import OAuthClient
+from apricot.oauth import OAuthClient, OAuthDataAdaptor
 
 from .oauth_ldap_tree import OAuthLDAPTree
 from .read_only_ldap_server import ReadOnlyLDAPServer
@@ -14,27 +14,24 @@ class OAuthLDAPServerFactory(ServerFactory):
 
     def __init__(
         self: Self,
-        domain: str,
+        oauth_adaptor: OAuthDataAdaptor,
         oauth_client: OAuthClient,
         *,
         background_refresh: bool,
-        enable_mirrored_groups: bool,
         refresh_interval: int,
     ) -> None:
         """Initialise an OAuthLDAPServerFactory.
 
         @param background_refresh: Whether to refresh the LDAP tree in the background rather than on access
-        @param domain: The root domain of the LDAP tree
-        @param enable_mirrored_groups: Create a mirrored LDAP group-of-groups for each group-of-users
-        @param oauth_client: An OAuth client used to construct the LDAP tree
+        @param oauth_adaptor: An OAuth data adaptor used to construct the LDAP tree
+        @param oauth_client: An OAuth client used to retrieve user and group data
         @param refresh_interval: Interval in seconds after which the tree must be refreshed
         """
         # Create an LDAP lookup tree
         self.adaptor = OAuthLDAPTree(
-            domain,
+            oauth_adaptor,
             oauth_client,
             background_refresh=background_refresh,
-            enable_mirrored_groups=enable_mirrored_groups,
             refresh_interval=refresh_interval,
         )
 

--- a/apricot/ldap/oauth_ldap_tree.py
+++ b/apricot/ldap/oauth_ldap_tree.py
@@ -77,6 +77,7 @@ class OAuthLDAPTree:
                 self.oauth_client,
                 enable_mirrored_groups=self.enable_mirrored_groups,
             )
+            oauth_adaptor.refresh()
 
             # Create a root node for the tree
             log.msg("Rebuilding LDAP tree.")

--- a/apricot/oauth/keycloak_client.py
+++ b/apricot/oauth/keycloak_client.py
@@ -75,9 +75,7 @@ class KeycloakClient(OAuthClient):
                         group_dict["id"],
                         int(group_gid[0], 10),
                     )
-
-            # Read group attributes
-            for group_dict in group_data:
+                # Set group attributes
                 if not group_dict["attributes"]["gid"]:
                     group_dict["attributes"]["gid"] = [
                         str(self.uid_cache.get_group_uid(group_dict["id"])),
@@ -87,6 +85,9 @@ class KeycloakClient(OAuthClient):
                         method="PUT",
                         json=group_dict,
                     )
+
+            # Read group attributes
+            for group_dict in group_data:
                 attributes: JSONDict = {}
                 attributes["cn"] = group_dict.get("name", None)
                 attributes["description"] = group_dict.get("id", None)
@@ -133,12 +134,7 @@ class KeycloakClient(OAuthClient):
                         user_dict["id"],
                         int(user_uid[0], 10),
                     )
-
-            # Read user attributes
-            for user_dict in sorted(
-                user_data,
-                key=operator.itemgetter("createdTimestamp"),
-            ):
+                # Set user attributes
                 if not user_dict["attributes"]["uid"]:
                     user_dict["attributes"]["uid"] = [
                         str(self.uid_cache.get_user_uid(user_dict["id"])),
@@ -148,6 +144,12 @@ class KeycloakClient(OAuthClient):
                         method="PUT",
                         json=user_dict,
                     )
+
+            # Read user attributes
+            for user_dict in sorted(
+                user_data,
+                key=operator.itemgetter("createdTimestamp"),
+            ):
                 # Get user attributes
                 first_name = user_dict.get("firstName", None)
                 last_name = user_dict.get("lastName", None)

--- a/apricot/oauth/keycloak_client.py
+++ b/apricot/oauth/keycloak_client.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import operator
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from twisted.python import log
 
-from apricot.typedefs import JSONDict
-
 from .oauth_client import OAuthClient
+
+if TYPE_CHECKING:
+    from apricot.typedefs import JSONDict
 
 
 class KeycloakClient(OAuthClient):
@@ -56,7 +57,7 @@ class KeycloakClient(OAuthClient):
                 f"{self.base_url}/admin/realms/{self.realm}/groups?first={len(group_data)}&max={self.max_rows}&briefRepresentation=false",
                 use_client_secret=False,
             ):
-                group_data.extend(cast(list[JSONDict], data))
+                group_data.extend(cast("list[JSONDict]", data))
                 if len(data) != self.max_rows:
                     break
 
@@ -99,7 +100,7 @@ class KeycloakClient(OAuthClient):
                     use_client_secret=False,
                 )
                 attributes["memberUid"] = [
-                    user["username"] for user in cast(list[JSONDict], members)
+                    user["username"] for user in cast("list[JSONDict]", members)
                 ]
                 output.append(attributes)
         except KeyError as exc:
@@ -115,7 +116,7 @@ class KeycloakClient(OAuthClient):
                 f"{self.base_url}/admin/realms/{self.realm}/users?first={len(user_data)}&max={self.max_rows}&briefRepresentation=false",
                 use_client_secret=False,
             ):
-                user_data.extend(cast(list[JSONDict], data))
+                user_data.extend(cast("list[JSONDict]", data))
                 if len(data) != self.max_rows:
                     break
 

--- a/apricot/oauth/microsoft_entra_client.py
+++ b/apricot/oauth/microsoft_entra_client.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import operator
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
 
 from twisted.python import log
 
-from apricot.typedefs import JSONDict
-
 from .oauth_client import OAuthClient
+
+if TYPE_CHECKING:
+    from apricot.typedefs import JSONDict
 
 
 class MicrosoftEntraClient(OAuthClient):
@@ -50,7 +51,7 @@ class MicrosoftEntraClient(OAuthClient):
             f"https://graph.microsoft.com/v1.0/groups?$select={','.join(queries)}",
         )
         for group_dict in cast(
-            list[JSONDict],
+            "list[JSONDict]",
             sorted(group_data["value"], key=operator.itemgetter("createdDateTime")),
         ):
             try:
@@ -92,7 +93,7 @@ class MicrosoftEntraClient(OAuthClient):
                 f"https://graph.microsoft.com/v1.0/users?$select={','.join(queries)}",
             )
             for user_dict in cast(
-                list[JSONDict],
+                "list[JSONDict]",
                 sorted(user_data["value"], key=operator.itemgetter("createdDateTime")),
             ):
                 # Get user attributes

--- a/apricot/oauth/oauth_client.py
+++ b/apricot/oauth/oauth_client.py
@@ -151,7 +151,7 @@ class OAuthClient(ABC):
     ) -> dict[str, Any]:
         """Make a request to the OAuth backend."""
 
-        def query_(*args: Any, **kwargs: Any) -> requests.Response:
+        def request_(*args: Any, **kwargs: Any) -> requests.Response:
             return self.session_application.request(  # type: ignore[no-any-return]
                 method,
                 *args,
@@ -160,12 +160,12 @@ class OAuthClient(ABC):
             )
 
         try:
-            result = query_(*args, **kwargs)
+            result = request_(*args, **kwargs)
             result.raise_for_status()
         except (TokenExpiredError, requests.exceptions.HTTPError) as exc:
             log.msg(f"Authentication token is invalid.\n{exc!s}")
             self.bearer_token_ = None
-            result = query_(*args, **kwargs)
+            result = request_(*args, **kwargs)
         if result.status_code == HTTPStatus.NO_CONTENT:
             return {}
         return result.json()  # type: ignore[no-any-return]

--- a/apricot/oauth/oauth_data_adaptor.py
+++ b/apricot/oauth/oauth_data_adaptor.py
@@ -40,18 +40,10 @@ class OAuthDataAdaptor:
         @param oauth_client: An OAuth client used to construct the LDAP tree
         """
         self.debug = oauth_client.debug
+        self.domain = domain
         self.oauth_client = oauth_client
         self.root_dn = "DC=" + domain.replace(".", ",DC=")
         self.enable_mirrored_groups = enable_mirrored_groups
-
-        # Retrieve and validate user and group information
-        annotated_groups, annotated_users = self._retrieve_entries()
-        self.validated_groups = self._validate_groups(annotated_groups)
-        self.validated_users = self._validate_users(annotated_users, domain)
-        if self.debug:
-            log.msg(
-                f"Validated {len(self.validated_groups)} groups and {len(self.validated_users)} users.",
-            )
 
     @property
     def groups(self: Self) -> list[LDAPAttributeAdaptor]:
@@ -233,3 +225,13 @@ class OAuthDataAdaptor:
                         f" -> '{error['loc'][0]}': {error['msg']} but '{error['input']}' was provided.",
                     )
         return output
+
+    def refresh(self) -> None:
+        """Retrieve and validate user and group information."""
+        annotated_groups, annotated_users = self._retrieve_entries()
+        self.validated_groups = self._validate_groups(annotated_groups)
+        self.validated_users = self._validate_users(annotated_users, self.domain)
+        if self.debug:
+            log.msg(
+                f"Validated {len(self.validated_groups)} groups and {len(self.validated_users)} users.",
+            )

--- a/apricot/oauth/oauth_data_adaptor.py
+++ b/apricot/oauth/oauth_data_adaptor.py
@@ -45,16 +45,6 @@ class OAuthDataAdaptor:
         self.root_dn = "DC=" + domain.replace(".", ",DC=")
         self.enable_mirrored_groups = enable_mirrored_groups
 
-    @property
-    def groups(self: Self) -> list[LDAPAttributeAdaptor]:
-        """Return a list of LDAPAttributeAdaptors representing validated group data."""
-        return self.validated_groups
-
-    @property
-    def users(self: Self) -> list[LDAPAttributeAdaptor]:
-        """Return a list of LDAPAttributeAdaptors representing validated user data."""
-        return self.validated_users
-
     def _dn_from_group_cn(self: Self, group_cn: str) -> str:
         return f"CN={group_cn},OU=groups,{self.root_dn}"
 
@@ -226,12 +216,15 @@ class OAuthDataAdaptor:
                     )
         return output
 
-    def refresh(self) -> None:
-        """Retrieve and validate user and group information."""
+    def retrieve_all(
+        self,
+    ) -> tuple[list[LDAPAttributeAdaptor], list[LDAPAttributeAdaptor]]:
+        """Retrieve and return validated user and group information."""
         annotated_groups, annotated_users = self._retrieve_entries()
-        self.validated_groups = self._validate_groups(annotated_groups)
-        self.validated_users = self._validate_users(annotated_users, self.domain)
+        validated_groups = self._validate_groups(annotated_groups)
+        validated_users = self._validate_users(annotated_users, self.domain)
         if self.debug:
             log.msg(
-                f"Validated {len(self.validated_groups)} groups and {len(self.validated_users)} users.",
+                f"Validated {len(validated_groups)} groups and {len(validated_users)} users.",
             )
+        return (validated_groups, validated_users)

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,6 +56,9 @@ if [ -n "${KEYCLOAK_BASE_URL}" ]; then
     fi
     EXTRA_OPTS="${EXTRA_OPTS} --keycloak-base-url $KEYCLOAK_BASE_URL --keycloak-realm $KEYCLOAK_REALM"
 fi
+if [ -n "${KEYCLOAK_DOMAIN_ATTRIBUTE}" ]; then
+    EXTRA_OPTS="${EXTRA_OPTS} --keycloak-domain-attribute $KEYCLOAK_DOMAIN_ATTRIBUTE"
+fi
 
 
 # LDAP refresh arguments

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,7 +2,37 @@
 # shellcheck disable=SC2086
 # shellcheck disable=SC2089
 
-# Required arguments
+# Optional arguments
+EXTRA_OPTS=""
+
+
+# Common server-level options
+if [ -z "${PORT}" ]; then
+    PORT="1389"
+    echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] PORT environment variable is not set: using default of '${PORT}'"
+fi
+
+if [ -n "${DEBUG}" ]; then
+    EXTRA_OPTS="${EXTRA_OPTS} --debug"
+fi
+
+
+# LDAP tree arguments
+if [ -z "${DOMAIN}" ]; then
+    echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] DOMAIN environment variable is not set"
+    exit 1
+fi
+
+if [ -n "${DISABLE_MIRRORED_GROUPS}" ]; then
+    EXTRA_OPTS="${EXTRA_OPTS} --disable-mirrored-groups"
+fi
+
+if [ -n "${DISABLE_USER_DOMAIN_VERIFICATION}" ]; then
+    EXTRA_OPTS="${EXTRA_OPTS} --disable-user-domain-verification"
+fi
+
+
+# OAuth client arguments
 if [ -z "${BACKEND}" ]; then
     echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] BACKEND environment variable is not set"
     exit 1
@@ -18,27 +48,14 @@ if [ -z "${CLIENT_SECRET}" ]; then
     exit 1
 fi
 
-if [ -z "${DOMAIN}" ]; then
-    echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] DOMAIN environment variable is not set"
-    exit 1
+
+# LDAP refresh arguments
+if [ -n "${BACKGROUND_REFRESH}" ]; then
+    EXTRA_OPTS="${EXTRA_OPTS} --background-refresh"
 fi
 
-
-# Arguments with defaults
-if [ -z "${PORT}" ]; then
-    PORT="1389"
-    echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] PORT environment variable is not set: using default of '${PORT}'"
-fi
-
-
-# Optional arguments
-EXTRA_OPTS=""
-if [ -n "${DEBUG}" ]; then
-    EXTRA_OPTS="${EXTRA_OPTS} --debug"
-fi
-
-if [ -n "${DISABLE_MIRRORED_GROUPS}" ]; then
-    EXTRA_OPTS="${EXTRA_OPTS} --disable-mirrored-groups"
+if [ -n "${REFRESH_INTERVAL}" ]; then
+    EXTRA_OPTS="${EXTRA_OPTS} --refresh-interval $REFRESH_INTERVAL"
 fi
 
 
@@ -61,13 +78,13 @@ if [ -n "${KEYCLOAK_DOMAIN_ATTRIBUTE}" ]; then
 fi
 
 
-# LDAP refresh arguments
-if [ -n "${BACKGROUND_REFRESH}" ]; then
-    EXTRA_OPTS="${EXTRA_OPTS} --background-refresh"
-fi
-
-if [ -n "${REFRESH_INTERVAL}" ]; then
-    EXTRA_OPTS="${EXTRA_OPTS} --refresh-interval $REFRESH_INTERVAL"
+# Redis arguments
+if [ -n "${REDIS_HOST}" ]; then
+    if [ -z "${REDIS_PORT}" ]; then
+        REDIS_PORT="6379"
+        echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] REDIS_PORT environment variable is not set: using default of '${REDIS_PORT}'"
+    fi
+    EXTRA_OPTS="${EXTRA_OPTS} --redis-host $REDIS_HOST --redis-port $REDIS_PORT"
 fi
 
 
@@ -82,16 +99,6 @@ if [ -n "${TLS_PORT}" ]; then
         exit 1
     fi
     EXTRA_OPTS="${EXTRA_OPTS} --tls-port $TLS_PORT --tls-certificate $TLS_CERTIFICATE --tls-private-key $TLS_PRIVATE_KEY"
-fi
-
-
-# Redis arguments
-if [ -n "${REDIS_HOST}" ]; then
-    if [ -z "${REDIS_PORT}" ]; then
-        REDIS_PORT="6379"
-        echo "$(date +'%Y-%m-%d %H:%M:%S+0000') [-] REDIS_PORT environment variable is not set: using default of '${REDIS_PORT}'"
-    fi
-    EXTRA_OPTS="${EXTRA_OPTS} --redis-host $REDIS_HOST --redis-port $REDIS_PORT"
 fi
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,10 +168,10 @@ strict = true                     # enable all optional error checking flags
 
 [[tool.mypy.overrides]]
 module = [
-    "ldaptor.*",
-    "pydantic.*",
-    "requests_oauthlib.*",
-    "twisted.*",
-    "zope.interface.*",
+  "ldaptor.*",
+  "pydantic.*",
+  "requests_oauthlib.*",
+  "twisted.*",
+  "zope.interface.*",
 ]
 ignore_missing_imports = true

--- a/run.py
+++ b/run.py
@@ -10,20 +10,7 @@ if __name__ == "__main__":
             prog="Apricot",
             description="Apricot is a proxy for delegating LDAP requests to an OpenID Connect backend.",
         )
-        # Common options needed for all backends
-        parser.add_argument(
-            "-b",
-            "--backend",
-            type=OAuthBackend,
-            help="Which OAuth backend to use.",
-        )
-        parser.add_argument(
-            "-d",
-            "--domain",
-            type=str,
-            help="Which domain users belong to.",
-        )
-        parser.add_argument("-i", "--client-id", type=str, help="OAuth client ID.")
+        # Common server-level options
         parser.add_argument(
             "-p",
             "--port",
@@ -32,30 +19,68 @@ if __name__ == "__main__":
             help="Port to run on.",
         )
         parser.add_argument(
-            "-s",
-            "--client-secret",
-            type=str,
-            help="OAuth client secret.",
-        )
-        parser.add_argument(
-            "--background-refresh",
-            action="store_true",
-            default=False,
-            help="Refresh in the background instead of as needed per request",
-        )
-        parser.add_argument(
             "--debug",
             action="store_true",
             help="Enable debug logging.",
         )
-        parser.add_argument(
+
+        # LDAP tree settings
+        ldap_group = parser.add_argument_group("LDAP tree settings")
+        ldap_group.add_argument(
+            "-d",
+            "--domain",
+            type=str,
+            help="Which domain users belong to.",
+            required=True,
+        )
+        ldap_group.add_argument(
             "--disable-mirrored-groups",
             action="store_false",
             default=True,
             dest="enable_mirrored_groups",
             help="Disable creation of mirrored groups.",
         )
-        parser.add_argument(
+        ldap_group.add_argument(
+            "--disable-user-domain-verification",
+            action="store_false",
+            default=True,
+            dest="enable_user_domain_verification",
+            help="Disable check that users belong to the correct domain.",
+        )
+
+        # OAuth client settings
+        oauth_group = parser.add_argument_group("OAuth settings")
+        oauth_group.add_argument(
+            "-b",
+            "--backend",
+            type=OAuthBackend,
+            help="Which OAuth backend to use.",
+            required=True,
+        )
+        oauth_group.add_argument(
+            "-i",
+            "--client-id",
+            type=str,
+            help="OAuth client ID.",
+            required=True,
+        )
+        oauth_group.add_argument(
+            "-s",
+            "--client-secret",
+            type=str,
+            help="OAuth client secret.",
+            required=True,
+        )
+
+        # Options for refreshing the tree
+        refresh_group = parser.add_argument_group("Refresh settings")
+        refresh_group.add_argument(
+            "--background-refresh",
+            action="store_true",
+            default=False,
+            help="Refresh in the background instead of as needed per request",
+        )
+        refresh_group.add_argument(
             "--refresh-interval",
             type=int,
             default=60,
@@ -63,7 +88,7 @@ if __name__ == "__main__":
         )
 
         # Options for Microsoft Entra backend
-        entra_group = parser.add_argument_group("Microsoft Entra")
+        entra_group = parser.add_argument_group("Microsoft Entra backend")
         entra_group.add_argument(
             "--entra-tenant-id",
             type=str,
@@ -71,7 +96,7 @@ if __name__ == "__main__":
         )
 
         # Options for Keycloak backend
-        keycloak_group = parser.add_argument_group("Keycloak")
+        keycloak_group = parser.add_argument_group("Keycloak backend")
         keycloak_group.add_argument(
             "--keycloak-base-url",
             type=str,
@@ -88,6 +113,7 @@ if __name__ == "__main__":
             default="domain",
             help="The attribute in Keycloak that contains the users' domain.",
         )
+
         # Options for Redis cache
         redis_group = parser.add_argument_group("Redis")
         redis_group.add_argument(
@@ -100,6 +126,7 @@ if __name__ == "__main__":
             type=int,
             help="Port for Redis server.",
         )
+
         # Options for TLS
         tls_group = parser.add_argument_group("TLS")
         tls_group.add_argument(
@@ -118,6 +145,7 @@ if __name__ == "__main__":
             type=str,
             help="Location of TLS private key (pem).",
         )
+
         # Parse arguments
         args = parser.parse_args()
 


### PR DESCRIPTION
- Improves documentation about how to use Keycloak
- Drops the suggested method of adding a client-scoped mapper to expose a hardcoded domain as this was not working in some cases for an unknown reason
- Move OAuthDataMapper to once-per-server to simplify various nested constructors
- Adds a `--disable-user-domain-verification` flag for cases where domain validation is not wanted
- Enables `--keycloak-domain-attribute` to be set from Docker

Closes #54. Closes #55.