### PR TITLE
Fix overloaded function error

### DIFF
--- a/apricot/cache/local_cache.py
+++ b/apricot/cache/local_cache.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from typing import Self, overload
+from typing import Self
+
+from typing_extensions import override
 
 from .uid_cache import UidCache
 
@@ -12,18 +14,18 @@ class LocalCache(UidCache):
         """Initialise a RedisCache."""
         self.cache: dict[str, int] = {}
 
-    @overload  # type: ignore[misc]
+    @override
     def get(self: Self, identifier: str) -> int | None:
         return self.cache.get(identifier, None)
 
-    @overload  # type: ignore[misc]
+    @override
     def keys(self: Self) -> list[str]:
         return [str(k) for k in self.cache]
 
-    @overload  # type: ignore[misc]
+    @override
     def set(self: Self, identifier: str, uid_value: int) -> None:
         self.cache[identifier] = uid_value
 
-    @overload  # type: ignore[misc]
+    @override
     def values(self: Self, keys: list[str]) -> list[int]:
         return [v for k, v in self.cache.items() if k in keys]

--- a/apricot/cache/redis_cache.py
+++ b/apricot/cache/redis_cache.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Self, cast, overload
+from typing import Self, cast
 
 import redis
+from typing_extensions import override
 
 from .uid_cache import UidCache
 
@@ -36,19 +37,19 @@ class RedisCache(UidCache):
             )
         return self.cache_
 
-    @overload  # type: ignore[misc]
+    @override
     def get(self: Self, identifier: str) -> int | None:
         value = self.cache.get(identifier)
         return None if value is None else int(value)
 
-    @overload  # type: ignore[misc]
+    @override
     def keys(self: Self) -> list[str]:
         return [str(k) for k in self.cache.keys()]  # noqa: SIM118
 
-    @overload  # type: ignore[misc]
+    @override
     def set(self: Self, identifier: str, uid_value: int) -> None:
         self.cache.set(identifier, uid_value)
 
-    @overload  # type: ignore[misc]
+    @override
     def values(self: Self, keys: list[str]) -> list[int]:
         return [int(cast("str", v)) for v in self.cache.mget(keys)]

--- a/apricot/oauth/keycloak_client.py
+++ b/apricot/oauth/keycloak_client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Any, Self, cast, overload
+from typing import TYPE_CHECKING, Any, Self, cast
+
+from typing_extensions import override
 
 from .oauth_client import OAuthClient
 
@@ -45,12 +47,12 @@ class KeycloakClient(OAuthClient):
             **kwargs,
         )
 
-    @overload  # type: ignore[misc]
+    @override
     @staticmethod
     def extract_token(json_response: JSONDict) -> str:
         return str(json_response["access_token"])
 
-    @overload  # type: ignore[misc]
+    @override
     def groups(self: Self) -> list[JSONDict]:
         output = []
         try:
@@ -110,7 +112,7 @@ class KeycloakClient(OAuthClient):
             self.logger.warn(msg)
         return output
 
-    @overload  # type: ignore[misc]
+    @override
     def users(self: Self) -> list[JSONDict]:
         output = []
         try:

--- a/apricot/oauth/microsoft_entra_client.py
+++ b/apricot/oauth/microsoft_entra_client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import operator
-from typing import TYPE_CHECKING, Any, Self, cast, overload
+from typing import TYPE_CHECKING, Any, Self, cast
+
+from typing_extensions import override
 
 from .oauth_client import OAuthClient
 
@@ -36,12 +38,12 @@ class MicrosoftEntraClient(OAuthClient):
             **kwargs,
         )
 
-    @overload  # type: ignore[misc]
+    @override
     @staticmethod
     def extract_token(json_response: JSONDict) -> str:
         return str(json_response["access_token"])
 
-    @overload  # type: ignore[misc]
+    @override
     def groups(self: Self) -> list[JSONDict]:
         output = []
         queries = [
@@ -81,7 +83,7 @@ class MicrosoftEntraClient(OAuthClient):
                 )
         return output
 
-    @overload  # type: ignore[misc]
+    @override
     def users(self: Self) -> list[JSONDict]:
         output = []
         try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dependencies = [
   "types-oauthlib~=3.2",
   "types-redis~=4.6",
   "types-requests~=2.31",
+  "typing-extensions~=4.12",
 ]
 
 [tool.hatch.envs.lint.scripts]
@@ -101,7 +102,7 @@ known-first-party = ["apricot"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
-ignore-decorators = ["typing.overload"]
+ignore-decorators = ["typing.override"]
 
 [tool.mypy]
 disallow_subclassing_any = false  # allow subclassing of types from third-party libraries


### PR DESCRIPTION
Use override instead of overloaded to decorate inherited methods

Closes #65.